### PR TITLE
build: :fire: remove deprecated qs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,6 @@ Imports:
     knitr,
     magrittr,
     ps,
-    qs (>= 0.27.3),
     qs2,
     remotes,
     rmarkdown,


### PR DESCRIPTION
As done in leha. This removes the deprecated qs package. qs2 is the new one.

Closes #10 